### PR TITLE
Configure package.json for recommendation engine with uvicorn integration

### DIFF
--- a/apps/recommendation_engine/package.json
+++ b/apps/recommendation_engine/package.json
@@ -2,14 +2,18 @@
   "name": "recommendation-engine",
   "version": "1.0.0",
   "description": "Python app that ingests user messages and outputs a product recommendation",
-  "main": "main.py",
+  "main": "search_engine.py",
   "scripts": {
-    "dev": "python main.py",
-    "build": "echo 'Python build complete'",
+    "predev": "pip install -r requirements.txt",
+    "dev": "uvicorn search_engine:app --reload --host 0.0.0.0 --port 8000",
+    "start": "uvicorn search_engine:app --host 0.0.0.0 --port 8000",
+    "prebuild": "pip install -r requirements.txt",
+    "build": "echo 'Python dependencies installed and ready for deployment'",
+    "install": "pip install -r requirements.txt",
     "test": "python -m pytest tests/ || echo 'No tests found'",
     "lint": "python -m flake8 . || echo 'Linting complete'"
   },
-  "keywords": ["python", "recommendation", "ai", "gifts"],
+  "keywords": ["python", "recommendation", "ai", "gifts", "fastapi", "uvicorn"],
   "author": "Autogifter",
   "license": "MIT"
 }

--- a/apps/recommendation_engine/requirements.txt
+++ b/apps/recommendation_engine/requirements.txt
@@ -1,7 +1,7 @@
 requests>=2.31.0
 python-dotenv>=1.0.0
 openai>=1.0.0
-fastapi
-uvicorn 
-httpx 
-python-dotenv
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+httpx>=0.25.0
+pydantic>=2.0.0


### PR DESCRIPTION
# Configure package.json for Recommendation Engine

This PR configures the package.json for the recommendation engine to properly integrate with the monorepo setup and enable easy server management.

## Changes Made

### Updated `apps/recommendation_engine/package.json`:
- **Fixed main entry point**: Changed from non-existent `main.py` to `search_engine.py` 
- **Added proper dev script**: Now uses `uvicorn search_engine:app --reload --host 0.0.0.0 --port 8000`
- **Added dependency management**: `predev` and `prebuild` scripts automatically install Python dependencies
- **Added production start script**: `npm run start` for production deployment
- **Enhanced keywords**: Added FastAPI and uvicorn related keywords

### Updated `apps/recommendation_engine/requirements.txt`:
- **Removed duplicate**: Eliminated duplicate `python-dotenv` entry
- **Added version constraints**: Specified minimum versions for better dependency management
- **Added missing dependency**: Added `pydantic>=2.0.0` for FastAPI data validation
- **Improved uvicorn**: Changed to `uvicorn[standard]` for better performance

## Usage

The recommendation engine can now be run using standard npm commands that integrate with the Turbo monorepo:

```bash
# Development with hot reload (automatically installs dependencies)
npm run dev

# Production server
npm run start  

# Install dependencies only
npm run install

# Build (installs dependencies for deployment)
npm run build
```

## Testing

✅ Successfully tested the configuration:
- Dependencies install automatically via `predev` script
- Server starts correctly on http://0.0.0.0:8000
- Hot reload functionality works
- Integrates seamlessly with existing Turbo monorepo setup

## Integration

This maintains compatibility with the user's current workflow while adding proper npm integration:
- Previous command: `uvicorn apps.recommendation_engine.search_engine:app --reload`  
- New command: `npm run dev` (from the recommendation_engine directory)
- Or from root: `turbo dev` (runs all apps including recommendation engine)

Link to Devin run: https://app.devin.ai/sessions/b424b4f70cfd43c195640b7eb09691c6
Requested by: Alfonso (alfonso@alfongj.com)
